### PR TITLE
Rudimentary Vuetify XPath helper

### DIFF
--- a/girder_pytest_pyppeteer/vuetify_xpath.py
+++ b/girder_pytest_pyppeteer/vuetify_xpath.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from json import JSONEncoder
+
+# Pyppeteer uses json.JSONEncoder to send any arguments to the Puppeteer API.
+# We do this monkeypatching so that we can send raw XPath arguments directly.
+# Any object with a __to_json__ method will be encodeable by pyppeteer.
+
+# Monkey patch the JSONEncoder method which handles unsupported data types
+def _default(self, obj):
+    return getattr(obj.__class__, "__to_json__", _default.default)(obj)
+
+
+_default.default = JSONEncoder.default  # Save unmodified default.
+JSONEncoder.default = _default  # Replace it.
+
+
+class XPath:
+    def __init__(self, xpath='*'):
+        self._xpath = xpath
+    
+    @property
+    def bare(self):
+        return self._xpath
+    
+    @property
+    def recursive(self):
+        # Search the entire document recursively for this XPath
+        return f'//{self._xpath}'
+    
+    @property
+    def local(self):
+        # Search a given element for this XPath
+        return f'./{self._xpath}'
+
+    def __str__(self):
+        return self.recursive
+    
+    def __to_json__(self):
+        return str(self)
+    
+    def extend(self, extension: str):
+        return XPath(f'{self.bare}{extension}')
+    
+    def predicate(self, predicate: str):
+        return self.extend(f'[{predicate}]')
+
+    def __truediv__(self, other: XPath):
+        return self.extend(f'/{other.bare}')
+
+    def __floordiv__(self, other: XPath):
+        return self.extend(f'//{other.bare}')
+    
+    def __getitem__(self, key: XPath):
+        return self.predicate(key.bare)
+    
+    @property
+    def parent(self):
+        return self / '..'
+    
+    def with_class(self, clazz: str):
+        # This magic ensures that calling with_class('v-btn') doesn't match the class 'v-btn__extra'
+        return self.predicate(f'contains(concat(" ",@class," ")," {clazz} ")')
+    
+    def contains(self, text: str):
+        return self.predicate(f'contains(.,"{text}")')
+
+def VBtn(content=None):
+    xpath = XPath().with_class('v-btn')
+    if content:
+        # xpath = f'{xpath}[*[@class="v-btn__content"][contains(.,"{content}")]]'
+        xpath = xpath[XPath().with_class('v-btn__content').contains(content)]
+    return xpath
+
+print(VBtn())
+print(VBtn('click me!'))
+print(VBtn(content='New Dandiset'))
+print(VBtn('foo')/VBtn('bar'))
+print(VBtn('foo')//VBtn('bar'))
+print(VBtn('foo')[VBtn('bar')])


### PR DESCRIPTION
This is a very basic XPath helper class. It implements the `/`, `//`, and `[...]` operators like normal XPaths do, and has some helpers like `with_class` to help eliminate a lot of boilerplate. It also includes a monkeypatch on `json.JSONEncoder`, which pyppeteer uses to serialize any arguments to any puppeteer functions. This allows you to pass XPath objects directly to pyppeteer.

To finalize this helper, I would recommend:
* Writing a few Vuetify helpers like the `VBtn` helper included here, but with a more complete API. https://github.com/girder/jest-puppeteer-vuetify/blob/master/src/vuetify-xpaths.ts may be a good source of inspiration. If you press ctrl+f in the Elements tab of Chrome DevTools, you get a search box that you can test XPaths in: 
![image](https://user-images.githubusercontent.com/577946/167867652-88f450ed-f664-4f5b-b42b-5f1ff79f448b.png)
* Finalize the API surface of XPath as much as possible. What works well, what doesn't, what should be capitalized/uncapitalized, etc. Don't feel attached to any decisions I made, I intended to reevaluate most of this class before publication.
  * Be aware of inputs like vTextField. Sometimes you want to write an expression like `vInput()[vIcon(...)]`, which means `vInput` needs to identify the root div of the input component rather than the input element itself. However, sometimes you want to write `page.sendKeys(vInput(...))`, which means `vInput` needs to return the input element directly so the key presses go to the correct element. For [vTextField](https://github.com/girder/jest-puppeteer-vuetify/blob/master/src/vuetify-xpaths.ts#L168-L171) I chose the input element, but I don't know that that was correct. Both use cases are important, use your best judgement.
  * I made `VBtn` a function, but maybe the helpers should be classes that extend `XPath` instead. If a particular v-element ever needs it's own helper methods that aren't generalizable to XPath, then perhaps that would be a sensible change to make.
* Add the vuetify helper to the `girder_pytest_pyppeteer` package so that tests can use it.
* Add some Vuetify elements to the test app and add some tests for the helpers you wrote.

Something to keep in mind: [Vuetify 3](https://vuetifyjs.com/en/introduction/roadmap/#v3-0-titan) is releasing momentarily, and will likely break any helpers written for [Vuetify 2](https://vuetifyjs.com/en/introduction/roadmap/#v2-7). There's still at least a year left of life in Vuetify 2. This library is for Girder 4 projects, so this won't really be a concern until a critical mass of Girder 4 projects start using Vuetify 3. 